### PR TITLE
Fix padding issue in equation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -306,7 +306,7 @@ time-step to the probability of an output sequence.</p>
 for a single <d-math>(X, Y)</d-math> pair is:</p>
 
 <figure class="figure-math" style="width:100%;">
-  <div style="display:grid;grid-template-rows:50% 50%;margin-top: -2.5em;">
+  <div style="display:grid;grid-template-rows:70% 30%;margin-top: -2.5em;">
   <div style="display:grid;grid-template-columns:20% 20% 30%;grid-column-gap:5%">
     <div style="line-height:75px;min-width:125px;">
       <d-math block>p(Y \mid X) \;\; =</d-math>


### PR DESCRIPTION
Before:

<img width="625" alt="Screen Shot 2019-11-12 at 1 53 51 PM" src="https://user-images.githubusercontent.com/1542805/68701188-3a327b00-0554-11ea-8dc9-cea902e815b3.png">

After:

<img width="639" alt="Screen Shot 2019-11-12 at 1 56 47 PM" src="https://user-images.githubusercontent.com/1542805/68701223-4a4a5a80-0554-11ea-8689-1e53e28b874a.png">
